### PR TITLE
Fix host init when host value doesn't ends with slash

### DIFF
--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -59,7 +59,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
             verify_ssl = True
     configuration = Configuration()
     configuration.api_key['Authorization'] = api_key
-    configuration.host = base_url or os.getenv('DEMISTO_BASE_URL', None)
+    configuration.host = os.path.join(base_url or os.getenv('DEMISTO_BASE_URL', None), '')
     configuration.verify_ssl = verify_ssl
     configuration.proxy = proxy
     configuration.debug = debug


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Fix host init when host value doesn't ends with slash to avoid errors when execute API calls in demisto client.

## Must have
- [ ] Unit Test or Example Code
- [ ] Changelog entry
