### PR TITLE
Stop using deprecated pytz.localize function

### DIFF
--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -202,7 +202,8 @@ def to_extended_dict(o):
                 ))
             elif isinstance(value, datetime.datetime):
                 if not value.tzinfo:  # no tz defined -> use machine local
-                    value = tzlocal.get_localzone().localize(value)
+                    local_tz = tzlocal.get_localzone()
+                    value = value.replace(tzinfo=local_tz)
                 result[o_map[attr]] = value.isoformat()
             else:
                 result[o_map[attr]] = value


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/48250
fixes: https://github.com/demisto/demisto-sdk/issues/2035

## Description
Stop using the deprecated pytz.localize function and use datetime.replace(tzinfo) instead.
