### PR TITLE
Adding exception for wrong base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 [PyPI History][1]
 [1]: https://pypi.org/project/demisto-py/#history
 
-## 3.2.6
-* Added support for proxy basic authentication.
+## 3.2.7
+* Added an ability to change `DEMISTO_BASE_URL` environment variable to api url, when using XSIAM.
 
 ## 3.2.6
-* Added an ability to change `DEMISTO_BASE_URL` environment variable to api url, when using XSIAM.
+* Added support for proxy basic authentication.
 
 ## 3.2.5
 * Fixed an issue where demisto-py failed to upload content to XSIAM when `DEMISTO_USERNAME` environment variable is set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 [PyPI History][1]
 [1]: https://pypi.org/project/demisto-py/#history
 
+## 3.2.6
+* Added an ability to change `DEMISTO_BASE_URL` environment variable to api url, when using XSIAM.
+
 ## 3.2.5
 * Fixed an issue where demisto-py failed to upload content to XSIAM when `DEMISTO_USERNAME` environment variable is set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 [PyPI History][1]
 [1]: https://pypi.org/project/demisto-py/#history
 
-## 3.2.4
+## 3.2.5
 * Fixed an issue where demisto-py failed to upload content to XSIAM when `DEMISTO_USERNAME` environment variable is set.
 
-## 3.2.3
+## 3.2.4
 * Fixed an issue where demisto-py did not return partial errors when importing incident fields.
+
+## 3.2.3
+* Add reputation routes.
 
 ## 3.2.2
 * Re-added Python 3.8 support.

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -97,11 +97,11 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     configuration = Configuration()
     configuration.api_key['Authorization'] = api_key
     configuration.host = os.path.join(base_url)
-    if auth_id and not configuration.host.startswith("https://api-"):
-        configuration.host = configuration.host.replace('https://', 'https://api-')
     if auth_id:
         configuration.api_key['x-xdr-auth-id'] = auth_id
         configuration.host = os.path.join(configuration.host, 'xsoar')
+        if not configuration.host.startswith("https://api-"):
+            configuration.host = configuration.host.replace('https://', 'https://api-')
     configuration.verify_ssl = verify_ssl
     configuration.proxy = proxy
     configuration.debug = debug

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -97,6 +97,9 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     configuration = Configuration()
     configuration.api_key['Authorization'] = api_key
     configuration.host = os.path.join(base_url)
+    if auth_id and not str(configuration.host).startswith("https://api-"):
+        raise ValueError(f'Using XSIAM, DEMISTO_BASE_URL should start with `https://api-`. '
+                         f'Your current URL is: {configuration.host}')
     if auth_id:
         configuration.api_key['x-xdr-auth-id'] = auth_id
         configuration.host = os.path.join(configuration.host, 'xsoar')

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -97,9 +97,8 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     configuration = Configuration()
     configuration.api_key['Authorization'] = api_key
     configuration.host = os.path.join(base_url)
-    if auth_id and not str(configuration.host).startswith("https://api-"):
-        raise ValueError(f'Using XSIAM, DEMISTO_BASE_URL should start with `https://api-`. '
-                         f'Your current URL is: {configuration.host}')
+    if auth_id and not configuration.host.startswith("https://api-"):
+        configuration.host = configuration.host.replace('https://', 'https://api-')
     if auth_id:
         configuration.api_key['x-xdr-auth-id'] = auth_id
         configuration.host = os.path.join(configuration.host, 'xsoar')


### PR DESCRIPTION
I get a lot of questions "why the demisto-sdk upload is not working?" 
It is already written in the documentation of demisto-sdk upload and in confluence to use "base_url" from the XSIAM server -> Settings -> Configurations -> API Keys -> Copy URL. 

Adding exception inorder not to debug a lot of code in order to understand why it is not working. 