### PR TITLE
add custom http headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 [PyPI History][1]
 [1]: https://pypi.org/project/demisto-py/#history
 
-#3.2.9
+## 3.2.9
 * Added the ability to add custom request headers.
 
-# 3.2.8
+## 3.2.8
 * Fixed an issue where demisto-py used username/password authentication even when api-key was provided.
 
 ## 3.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [1]: https://pypi.org/project/demisto-py/#history
 
 #3.2.9
-* Added the ability to use custom headers for each request.
+* Added the ability to add custom request headers.
 
 # 3.2.8
 * Fixed an issue where demisto-py used username/password authentication even when api-key was provided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 [PyPI History][1]
 [1]: https://pypi.org/project/demisto-py/#history
 
+#3.2.9
+* Added the ability to use custom headers for each request.
+
 # 3.2.8
 * Fixed an issue where demisto-py used username/password authentication even when api-key was provided.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Follow these instructions to generate your Demisto API Key.
 1. In Demisto, navigate to **Settings > API Keys**.
 2. Click the **Generate Your Key** button.
 
-To avoid hard coding configurations in your code, it is possible to specify configruation params
+To avoid hard coding configurations in your code, it is possible to specify configuration params
 as the following environment variables (env variables will be used if parameters are not specified):
 
 * DEMISTO_BASE_URL
 * DEMISTO_API_KEY
 * DEMISTO_USERNAME
 * DEMISTO_PASSWORD
+* DEMISTO_HTTP_HEADERS (must be in the form of: header1=value1,header2=value2,header3=value3,...headerN=valueN)
 * DEMISTO_VERIFY_SSL (true/false. Default: true)
 * XSIAM_AUTH_ID (for Cortex XSIAM only. If set, Cortex XSIAM API will be used)
 * SSL_CERT_FILE (specify an alternate certificate bundle)

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -18,7 +18,7 @@ except DistributionNotFound:
 
 
 def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username=None, password=None,
-              ssl_ca_cert=None, debug=False, connection_pool_maxsize=None, auth_id=None):
+              ssl_ca_cert=None, debug=False, connection_pool_maxsize=None, auth_id=None, additional_headers=None):
     """
     This wrapper provides an easier to use method of configuring the API client. The base
     Configuration method is still exposed if you wish to further configure the API Client.
@@ -31,6 +31,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     * DEMISTO_USERNAME
     * DEMISTO_PASSWORD
     * DEMISTO_VERIFY_SSL (true/false. Default: true)
+    * DEMISTO_HTTP_HEADERS (header1=value1,header2=value2,header3=value3)
     * XSIAM_AUTH_ID
     * SSL_CERT_FILE (specify an alternate certificate bundle)
     * DEMISTO_CONNECTION_POOL_MAXSIZE (specify a connection pool max size)
@@ -47,6 +48,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     :param debug: bool - Include verbose logging.
     :param connection_pool_maxsize: int - specify a connection max pool size
     :param auth_id: str - api_key_id only for the xsiam
+    :param additional_headers: dict - additional_headers to send to every http request to demisto.
     :return: Returns an API client configuration identical to the Configuration() method.
     """
     if base_url is None:
@@ -61,6 +63,11 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
         username = os.getenv('DEMISTO_USERNAME')
     if password is None:
         password = os.getenv('DEMISTO_PASSWORD')
+    if additional_headers is None:
+        if headers := os.getenv('DEMISTO_HTTP_HEADERS'):
+            additional_headers = dict(header.split('=') for header in headers.split(','))
+        else:
+            additional_headers = {}
     if ssl_ca_cert is None:
         ssl_ca_cert = os.getenv('SSL_CERT_FILE')
     if verify_ssl is None:
@@ -112,15 +119,19 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     if api_key or auth_id:
         api_client = ApiClient(configuration)
         api_client.user_agent = 'demisto-py/' + __version__
+        api_client.default_headers.update(additional_headers)
         api_instance = demisto_api.DefaultApi(api_client)
         return api_instance
     else:
         api_instance = login(base_url=base_url, username=username, password=password,
-                             verify_ssl=verify_ssl, proxy=proxy, debug=debug)
+                             verify_ssl=verify_ssl, proxy=proxy, debug=debug, additional_headers=additional_headers)
         return api_instance
 
 
-def login(base_url=None, username=None, password=None, verify_ssl=True, proxy=None, debug=False):
+def login(
+    base_url=None, username=None, password=None, verify_ssl=True, proxy=None, debug=False, additional_headers=None
+):
+    additional_headers = additional_headers or {}
     configuration_orig = Configuration()
     configuration_orig.host = base_url or os.getenv('DEMISTO_BASE_URL', None)
     if isinstance(configuration_orig.host, str):
@@ -139,6 +150,7 @@ def login(base_url=None, username=None, password=None, verify_ssl=True, proxy=No
             raise ValueError(err_msg)
     api_client = ApiClient(configuration_orig)
     api_client.user_agent = 'demisto-py/' + __version__
+    api_client.default_headers.update(additional_headers)
     api_instance = demisto_api.DefaultApi(api_client)
     body = {
         "user": username,
@@ -162,6 +174,7 @@ def login(base_url=None, username=None, password=None, verify_ssl=True, proxy=No
     api_client = ApiClient(configuration, header_name="X-XSRF-TOKEN", header_value=xsrf_token,
                            cookie=cookies)
     api_client.user_agent = 'demisto-py/' + __version__
+    api_client.default_headers.update(additional_headers)
     mid_client = demisto_api.DefaultApi(api_client)
     second_call = generic_request_func(self=mid_client, path='/login', method='POST', body=body,
                                        accept='application/json', content_type='application/json')
@@ -169,6 +182,7 @@ def login(base_url=None, username=None, password=None, verify_ssl=True, proxy=No
     mid_api_client = ApiClient(configuration, header_name="X-XSRF-TOKEN", header_value=xsrf_token,
                                cookie=updated_cookies)
     mid_api_client.user_agent = 'demisto-py/' + __version__
+    mid_api_client.default_headers.update(additional_headers)
     final_api_client = demisto_api.DefaultApi(mid_api_client)
 
     return final_api_client
@@ -314,3 +328,4 @@ def get_layouts_url_for_demisto_version(api_client, params):
         if LooseVersion(server_details.get('demistoVersion')) >= LooseVersion('6.0.0'):
             url = '/layouts/import'
     return url
+

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -36,7 +36,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     * DEMISTO_USERNAME
     * DEMISTO_PASSWORD
     * DEMISTO_VERIFY_SSL (true/false. Default: true)
-    * DEMISTO_HTTP_HEADERS (header1=value1,header2=value2,header3=value3)
+    * DEMISTO_HTTP_HEADERS (must be in the form of: header1=value1,header2=value2,header3=value3,...headerN=valueN)
     * XSIAM_AUTH_ID
     * SSL_CERT_FILE (specify an alternate certificate bundle)
     * DEMISTO_CONNECTION_POOL_MAXSIZE (specify a connection pool max size)

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -19,7 +19,7 @@ except DistributionNotFound:
     __version__ = 'dev'
 
 
-DEMISTO_HTTP_HEADERS_PATTERN = r'^\w+=\w+(,\w+=\w+)*$'
+DEMISTO_HTTP_HEADERS_REGEX_PATTERN = r'^\w+=\w+(,\w+=\w+)*$'
 
 
 def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username=None, password=None,
@@ -70,7 +70,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
         password = os.getenv('DEMISTO_PASSWORD')
     if additional_headers is None:
         if headers := os.getenv('DEMISTO_HTTP_HEADERS'):
-            if re.match(DEMISTO_HTTP_HEADERS_PATTERN, headers):
+            if re.match(DEMISTO_HTTP_HEADERS_REGEX_PATTERN, headers):
                 additional_headers = dict(header.split('=') for header in headers.split(','))
             else:
                 raise ValueError(

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -70,7 +70,9 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
         password = os.getenv('DEMISTO_PASSWORD')
     if additional_headers is None:
         if headers := os.getenv('DEMISTO_HTTP_HEADERS'):
-            if re.match(DEMISTO_HTTP_HEADERS_REGEX_PATTERN, headers):
+            if re.match(r'^ *$', headers):
+                additional_headers = {}
+            elif re.match(DEMISTO_HTTP_HEADERS_REGEX_PATTERN, headers):
                 additional_headers = dict(header.strip().split('=') for header in headers.split(','))
             else:
                 raise ValueError(

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -70,7 +70,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
         password = os.getenv('DEMISTO_PASSWORD')
     if additional_headers is None:
         if headers := os.getenv('DEMISTO_HTTP_HEADERS'):
-            if re.match(r'^ *$', headers):
+            if re.match(r'^ *$', headers):  # catch any case of empty string
                 additional_headers = {}
             elif re.match(DEMISTO_HTTP_HEADERS_REGEX_PATTERN, headers):
                 additional_headers = dict(header.strip().split('=') for header in headers.split(','))

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -19,7 +19,7 @@ except DistributionNotFound:
     __version__ = 'dev'
 
 
-DEMISTO_HTTP_HEADERS_REGEX_PATTERN = r'^\w+=\w+(,\w+=\w+)*$'
+DEMISTO_HTTP_HEADERS_REGEX_PATTERN = r'^([\w-]+=[^=,\n]+)(,[\w-]+=[^=,\n]+)*$'
 
 
 def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username=None, password=None,
@@ -71,7 +71,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     if additional_headers is None:
         if headers := os.getenv('DEMISTO_HTTP_HEADERS'):
             if re.match(DEMISTO_HTTP_HEADERS_REGEX_PATTERN, headers):
-                additional_headers = dict(header.split('=') for header in headers.split(','))
+                additional_headers = dict(header.strip().split('=') for header in headers.split(','))
             else:
                 raise ValueError(
                     f'{headers} has invalid format, must be in the format of header1=value1,header2=value2,...headerN=valueN'

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -53,7 +53,7 @@ def configure(base_url=None, api_key=None, verify_ssl=None, proxy=None, username
     :param debug: bool - Include verbose logging.
     :param connection_pool_maxsize: int - specify a connection max pool size
     :param auth_id: str - api_key_id only for the xsiam
-    :param additional_headers: dict - additional_headers to send to every http request to demisto.
+    :param additional_headers: dict - any additional headers to send to every http request to demisto.
     :return: Returns an API client configuration identical to the Configuration() method.
     """
     if base_url is None:

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -679,6 +679,14 @@ class TestConfigureClient:
                 "Content-type=123",
                 {'Content-type': '123'}
             ),
+            (
+                "  ",
+                {}
+            ),
+            (
+                "",
+                {}
+            ),
         ]
     )
     def test_configure_client_valid_additional_headers_form_env_var(

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -610,7 +610,8 @@ class TestConfigureClient:
             "1=2,3=",
             "name=john,",
             "name=john age=42",
-            "bar="
+            "bar=",
+            "name,"
         ]
     )
     def test_configure_client_invalid_additional_headers_form_env_var(self, mocker, invalid_additional_headers):

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -20,7 +20,7 @@ def assert_reset():
     assert len(responses.calls) == 0
 
 
-def get_login_mocker(mocker, num_of_http_requests_mock=0):
+def get_login_mocker(mocker, num_of_http_requests_mock: int=0):
     from urllib3 import PoolManager
 
     raw_http_responses = [

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -592,3 +592,43 @@ class TestConfigureClient:
                 expected_additional_headers=expected_additional_headers
             )
 
+    @pytest.mark.parametrize(
+        "invalid_additional_headers",
+        [
+            "header1:value1,header2:value2",
+            "header1,value1,header2,value2",
+            "header1=value1,header2,value2",
+            "header1=value1,header2value2",
+            "header1=value1header2=value2",
+            "test",
+            "{header1:value1,header2:value2}",
+            "test=test,",
+            "test=test,test2=",
+            "test=test, test2=a",
+            "arg=arg,  c=d",
+            "arg-arg,  c=d"
+        ]
+    )
+    def test_configure_client_invalid_additional_headers_form_env_var(self, mocker, invalid_additional_headers):
+        """
+        Given:
+            invalid form of http headers
+
+        When:
+            configuring the client
+
+        Then:
+            make sure an exception is raised saying the format for invalid_additional_headers is invalid
+        """
+        mocker.patch.object(
+            os,
+            'getenv',
+            side_effect=self.getenv_decorator(additional_headers=invalid_additional_headers)
+        )
+
+        with pytest.raises(ValueError) as exc:
+            demisto_client.configure(base_url=host, api_key=api_key)
+
+        assert exc.value.args[0] == f'{invalid_additional_headers} has invalid format, must be in the format ' \
+                                    f'of header1=value1,header2=value2,...headerN=valueN'
+

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -606,7 +606,8 @@ class TestConfigureClient:
             "test=test,test2=",
             "test=test, test2=a",
             "arg=arg,  c=d",
-            "arg-arg,  c=d"
+            "arg-arg,  c=d",
+            "1=2,3=",
         ]
     )
     def test_configure_client_invalid_additional_headers_form_env_var(self, mocker, invalid_additional_headers):

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -702,4 +702,4 @@ class TestConfigureClient:
         )
 
         client = demisto_client.configure(base_url=host, api_key=api_key)
-        assert dict(header.split('=') for header in valid_additional_headers.split(',')).items() <= client.api_client.default_headers.items()
+        assert expected_headers_as_dict.items() <= client.api_client.default_headers.items()

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -608,6 +608,9 @@ class TestConfigureClient:
             "arg=arg,  c=d",
             "arg-arg,  c=d",
             "1=2,3=",
+            "name=john,",
+            "name=john age=42",
+            "bar="
         ]
     )
     def test_configure_client_invalid_additional_headers_form_env_var(self, mocker, invalid_additional_headers):


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4509)

## Description
add the ability to add custom http headers that will be sent in each http request
implements https://github.com/demisto/demisto-py/issues/103

## Must have
- [x] Unit Test or Example Code
- [x] Changelog entry
