### PR TITLE
Update DEMISTO_HTTP_HEADERS_REGEX_PATTERN to handle Cookie headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [PyPI History](https://pypi.org/project/demisto-py/#history)
 
+## 3.2.xx
+* Updated custom request headers validation logic to handle "Cookie" headers.
+
 ## 3.2.14
 * Added support for Python versions 3.11 and 3.12.
 

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -19,7 +19,7 @@ except DistributionNotFound:
     __version__ = 'dev'
 
 
-DEMISTO_HTTP_HEADERS_REGEX_PATTERN = r'^([\w-]+=[^=,\n]+)(,[\w-]+=[^=,\n]+)*$'
+DEMISTO_HTTP_HEADERS_REGEX_PATTERN = r'^(Cookie=[^,\n]+|[\w-]+=[^=,\n]+)(,(Cookie=[^,\n]+|[\w-]+=[^=,\n]+))*$'
 
 
 def configure(base_url=None, api_key=None, advanced_api_key=None, verify_ssl=None, proxy=None, username=None, password=None,

--- a/tests/mocks_test.py
+++ b/tests/mocks_test.py
@@ -721,6 +721,7 @@ class TestConfigureClient:
                 "Content-type=123",
                 {'Content-type': '123'}
             ),
+            
             (
                 "  ",
                 {}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: n/a

## Description
In the current implementation of DEMISTO_HTTP_HEADERS_REGEX_PATTERN it is not possible to pass 'Cookie: ' headers.
'Cookie' headers are usually passed in the following forms in a HTTP request:

One-liner:
`Cookie: key1=value; key2=value;
`
If one wants to pass this as a header in DEMISTO_HTTP_HEADERS_REGEX_PATTERN it should translate to 

`Cookie=key1=value; key2=value;
`

This is invalid with the current regex, because of white spaces and multiple '=' signs.

Multi-Liner:
`
Cookie: key1=value
Cookie: key2=value
`
If one wants to pass this as a header in DEMISTO_HTTP_HEADERS_REGEX_PATTERN it should translate to 

`Cookie=key1=value,Cookie=key2=value
`

This is also invalid with the current regex, because of multiple '=' signs.


My proposal with this merge proposal is to update the regex to handle the multi-liner case without breaking current behavior.
The updated regex handles specifically "Cookie" headers.

## Must have
- [X] Unit Test or Example Code
- [X] Changelog entry
