### PR TITLE
Update main.yml to explain use of SHA tags in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Setup Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
     
       - name: Install Poetry
-        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Install dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
           poetry run python -m pytest --junitxml=test-results/junit.xml -v tests -W ignore::DeprecationWarning
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
         with:
           name: test-results-${{ matrix.python-version }}
           path: test-results
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Verify
         run: |
@@ -69,15 +69,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Set up Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
         with:
           python-version: '3.12'
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Install dependencies
         run: |
@@ -99,15 +99,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Set up Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
         with:
           python-version: '3.12'
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4 Uses a commit SHA instead of a tag for deterministic builds—update the SHA to bump version.
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: internal discussion FYI @kobymeir @sapirshuker 

## Description
This update pins the GitHub Action by commit SHA instead of a version tag. This approach ensures deterministic builds by preventing issues caused by tag changes or retagging in the upstream repository.

## How to Bump the Version
To update to a newer version of the Action:
- Go to the Action’s repository on GitHub (e.g., actions/checkout).
- Navigate to the [Commits](https://github.com/actions/checkout/commits/main) tab.
- Copy the SHA of the desired commit.
- Replace the existing SHA in the workflow file (e.g., uses: actions/checkout@<sha>).
- Commit and push your changes.

Using a SHA ensures you always get the exact same code. You can update the SHA at any time to pull in changes as needed.

## Must have
- [ ] Unit Test or Example Code
- [ ] Changelog entry - Infra related, not necessary at this time
