### PR TITLE
Change `os.path.join()` usage to `posixpath.join()` because an URL is..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+## 3.2.23
+* Fix a bug where `os.path.join()` was used to create URLs, which caused issues on Windows systems.
+
 ## 3.2.22
 * Updated dependencies.
 

--- a/demisto_client/__init__.py
+++ b/demisto_client/__init__.py
@@ -6,6 +6,7 @@ import os
 import datetime
 import tzlocal
 import json
+import posixpath
 
 from demisto_client.demisto_api import ApiClient
 from demisto_client.demisto_api.configuration import Configuration
@@ -119,10 +120,10 @@ def configure(base_url=None, api_key=None, advanced_api_key=None, verify_ssl=Non
         setattr(configuration, 'auth_signed_key', advanced_api_key)
     else:
         configuration.api_key['Authorization'] = api_key
-    configuration.host = os.path.join(base_url)
+    configuration.host = posixpath.join(base_url)
     if auth_id:
         configuration.api_key['x-xdr-auth-id'] = auth_id
-        configuration.host = os.path.join(configuration.host, 'xsoar')
+        configuration.host = posixpath.join(configuration.host, 'xsoar')
         if not configuration.host.startswith("https://api-"):
             configuration.host = configuration.host.replace('https://', 'https://api-')
     configuration.verify_ssl = verify_ssl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-py"
-version = "3.2.22"
+version = "3.2.23"
 description = "\"A Python library for the Demisto API\""
 authors = ["Demisto"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Status
Ready

## Description
Change `os.path.join()` usage to `posixpath.join()` because an URL is always like a posixpath, it’s not OS-dependant.


## Must have
- [X] Unit Test or Example Code
- [ ] Changelog entry


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16553