### PR TITLE
Release v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-## 3.3.0
+## 3.3.1
 * Deprecated support for Python versions 3.9.
 * Added support for Python versions 3.13 and 3.14.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-py"
-version = "3.3.0"
+version = "3.3.1"
 description = "\"A Python library for the Demisto API\""
 authors = ["Demisto"]
 license = "Apache-2.0"


### PR DESCRIPTION


## Description
https://pypi.org/project/demisto-py/#history
Version 3.3.0 was already in use, so https://github.com/demisto/demisto-py/pull/167 failed to release

<img width="933" height="461" alt="image" src="https://github.com/user-attachments/assets/b830b1c6-102e-438e-ad47-f8a8b11a3fbc" />
